### PR TITLE
Add missing 'terminated' style

### DIFF
--- a/src/simvue_cli/cli/__init__.py
+++ b/src/simvue_cli/cli/__init__.py
@@ -535,7 +535,6 @@ def simvue_alert(ctx) -> None:
     default=20,
     show_default=True,
 )
-@click.option("--path", is_flag=True, help="Show path")
 @click.option("--run-tags", is_flag=True, help="Show tags")
 @click.option("--auto", is_flag=True, help="Show if run tag auto-assign is enabled")
 @click.option("--notification", is_flag=True, help="Show notification setting")

--- a/src/simvue_cli/cli/display.py
+++ b/src/simvue_cli/cli/display.py
@@ -36,9 +36,10 @@ STATUS_FORMAT: dict[str, str] = {
     "running": "blue",
     "failed": "red",
     "completed": "green",
-    "lost": "yellow",
+    "lost": "orange",
     "created": "white",
     "N/A": "grey",
+    "terminated": "red",
 }
 
 CLICK_COLORS: dict[str, str] = {


### PR DESCRIPTION
Adds the key `terminated` to formatting of statuses.