### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -7,6 +7,8 @@ jobs:
   build:
     name: Build Wheels and Package 🛠️
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/simvue-io/simvue-cli/security/code-scanning/1](https://github.com/simvue-io/simvue-cli/security/code-scanning/1)

To fix the issue, we will add a `permissions` block to the `build` job. Since the job only needs to read the repository contents (e.g., to check out code and build the module), we will set `contents: read` as the minimal required permission. This change ensures that the job does not have unnecessary write permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
