### PR TITLE
Fixed tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -108,7 +108,7 @@ def create_metadata_csv() -> pathlib.Path:
     N_RUNS: int = 40000
     _headers = ("first_name", "last_name", "email", "date")
     _fake = faker.Faker()
-    with tempfile.NamedTemporaryFile(delete_on_close=False, suffix=".csv") as temp_f:
+    with tempfile.NamedTemporaryFile(suffix=".csv") as temp_f:
         _file_path = pathlib.Path(temp_f.name)
         with _file_path.open("w") as out_f:
             out_f.write(",".join(_headers) + "\n")
@@ -127,10 +127,10 @@ def create_metadata_csv() -> pathlib.Path:
 def create_metadata_json(monkeypatch) -> pathlib.Path:
     import simvue_cli.push.core
     monkeypatch.setattr(simvue_cli.push.core, "BATCH_RUN_LIMIT", 10)
-    N_RUNS: int = 1000
+    N_RUNS: int = 40000
     _headers = ("first_name", "last_name", "email", "date")
     _fake = faker.Faker()
-    with tempfile.NamedTemporaryFile(delete_on_close=False, suffix=".json") as temp_f:
+    with tempfile.NamedTemporaryFile(suffix=".json") as temp_f:
         _file_path = pathlib.Path(temp_f.name)
         _out_data = []
         with _file_path.open("w") as out_f:
@@ -154,7 +154,7 @@ def create_runs_json(monkeypatch) -> pathlib.Path:
     N_METRICS: int = 10
     _headers = ("first_name", "last_name", "email", "date")
     _fake = faker.Faker()
-    with tempfile.NamedTemporaryFile(delete_on_close=False, suffix=".json") as temp_f:
+    with tempfile.NamedTemporaryFile(suffix=".json") as temp_f:
         _file_path = pathlib.Path(temp_f.name)
         _out_data = []
         with _file_path.open("w") as out_f:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -105,10 +105,10 @@ def setup_test_run(run: sv_run.Run, create_objects: bool, request: pytest.Fixtur
 
 @pytest.fixture
 def create_metadata_csv() -> pathlib.Path:
-    N_RUNS: int = 40000
+    N_RUNS: int = 100
     _headers = ("first_name", "last_name", "email", "date")
     _fake = faker.Faker()
-    with tempfile.NamedTemporaryFile(suffix=".csv") as temp_f:
+    with tempfile.NamedTemporaryFile(suffix=".csv", delete=False) as temp_f:
         _file_path = pathlib.Path(temp_f.name)
         with _file_path.open("w") as out_f:
             out_f.write(",".join(_headers) + "\n")
@@ -127,10 +127,10 @@ def create_metadata_csv() -> pathlib.Path:
 def create_metadata_json(monkeypatch) -> pathlib.Path:
     import simvue_cli.push.core
     monkeypatch.setattr(simvue_cli.push.core, "BATCH_RUN_LIMIT", 10)
-    N_RUNS: int = 40000
+    N_RUNS: int = 100
     _headers = ("first_name", "last_name", "email", "date")
     _fake = faker.Faker()
-    with tempfile.NamedTemporaryFile(suffix=".json") as temp_f:
+    with tempfile.NamedTemporaryFile(suffix=".json", delete=False) as temp_f:
         _file_path = pathlib.Path(temp_f.name)
         _out_data = []
         with _file_path.open("w") as out_f:
@@ -150,11 +150,11 @@ def create_metadata_json(monkeypatch) -> pathlib.Path:
 def create_runs_json(monkeypatch) -> pathlib.Path:
     import simvue_cli.push.core
     monkeypatch.setattr(simvue_cli.push.core, "BATCH_RUN_LIMIT", 10)
-    N_RUNS: int = 1000
+    N_RUNS: int = 100
     N_METRICS: int = 10
     _headers = ("first_name", "last_name", "email", "date")
     _fake = faker.Faker()
-    with tempfile.NamedTemporaryFile(suffix=".json") as temp_f:
+    with tempfile.NamedTemporaryFile(suffix=".json", delete=False) as temp_f:
         _file_path = pathlib.Path(temp_f.name)
         _out_data = []
         with _file_path.open("w") as out_f:

--- a/tests/test_command_line_interface.py
+++ b/tests/test_command_line_interface.py
@@ -734,7 +734,7 @@ def test_push_metadata_as_runs_csv(create_metadata_csv: str) -> None:
     assert _folder_id
     client = simvue.Client()
     runs = client.get_runs(filters=[f"folder.path == /simvue_cli_tests/{_uuid}"], count_limit=50000)
-    assert len(list(runs)) == 40000
+    assert len(list(runs)) == 100
     _folder = Folder(identifier=_folder_id, return_stats=True)
     with contextlib.suppress(ObjectNotFoundError):
         _folder.delete(recursive=True, delete_runs=True)
@@ -763,7 +763,7 @@ def test_push_metadata_as_runs_json(create_metadata_json: str) -> None:
     assert _folder_id
     client = simvue.Client()
     runs = client.get_runs(filters=[f"folder.path == /simvue_cli_tests/{_uuid}"], count_limit=50000)
-    assert len(list(runs)) == 40000
+    assert len(list(runs)) == 100
     _folder = Folder(identifier=_folder_id, return_stats=True)
     with contextlib.suppress(ObjectNotFoundError):
         _folder.delete(recursive=True, delete_runs=True)
@@ -790,7 +790,7 @@ def test_push_runs(create_runs_json: pathlib.Path) -> None:
     assert _folder_ids
     client = simvue.Client()
     runs = client.get_runs(filters=[f"folder.path == /simvue_cli_tests/{_uuid}"], count_limit=50000)
-    assert len(list(runs)) == 1000
+    assert len(list(runs)) == 100
     _folder = Folder(identifier=_folder_ids[0], return_status=True)
 
     if _folder := Client().get_folder(f"/simvue_cli_tests/{_uuid}"):

--- a/tests/test_command_line_interface.py
+++ b/tests/test_command_line_interface.py
@@ -720,6 +720,7 @@ def test_push_metadata_as_runs_csv(create_metadata_csv: str) -> None:
             "push",
             "runs",
             f"--folder=/simvue_cli_tests/{_uuid}",
+            "--name=test_push_metadata_as_runs_csv",
             "--tenant",
             "--metadata",
             "{\"batch_number\": 0}",
@@ -731,8 +732,10 @@ def test_push_metadata_as_runs_csv(create_metadata_csv: str) -> None:
     assert result.exit_code == 0, (result.stdout, result.stderr)
     _folder_id = result.stdout.strip()
     assert _folder_id
+    client = simvue.Client()
+    runs = client.get_runs(filters=[f"folder.path == /simvue_cli_tests/{_uuid}"], count_limit=50000)
+    assert len(list(runs)) == 40000
     _folder = Folder(identifier=_folder_id, return_stats=True)
-    assert _folder.to_dict()["runs"] == 1000, f"Expected 1000 runs in {_folder_id} but got {_folder.to_dict()['runs']}"
     with contextlib.suppress(ObjectNotFoundError):
         _folder.delete(recursive=True, delete_runs=True)
 
@@ -747,6 +750,7 @@ def test_push_metadata_as_runs_json(create_metadata_json: str) -> None:
             "runs",
             "--tenant",
             f"--folder=/simvue_cli_tests/{_uuid}",
+            "--name=test_push_metadata_as_runs_json",
             "--metadata",
             "{\"batch_number\": 0}",
             "--from-metadata",
@@ -757,8 +761,10 @@ def test_push_metadata_as_runs_json(create_metadata_json: str) -> None:
     assert result.exit_code == 0, (result.stdout, result.stderr)
     _folder_id = result.stdout.strip()
     assert _folder_id
+    client = simvue.Client()
+    runs = client.get_runs(filters=[f"folder.path == /simvue_cli_tests/{_uuid}"], count_limit=50000)
+    assert len(list(runs)) == 40000
     _folder = Folder(identifier=_folder_id, return_stats=True)
-    assert _folder.to_dict()["runs"] == 1000, f"Expected 1000 runs in {_folder_id} but got {_folder.to_dict()['runs']}"
     with contextlib.suppress(ObjectNotFoundError):
         _folder.delete(recursive=True, delete_runs=True)
 
@@ -782,8 +788,10 @@ def test_push_runs(create_runs_json: pathlib.Path) -> None:
     assert result.exit_code == 0, (result.stdout, result.stderr)
     _folder_ids = result.stdout.strip().split("\n")
     assert _folder_ids
+    client = simvue.Client()
+    runs = client.get_runs(filters=[f"folder.path == /simvue_cli_tests/{_uuid}"], count_limit=50000)
+    assert len(list(runs)) == 1000
     _folder = Folder(identifier=_folder_ids[0], return_status=True)
-    assert _folder.to_dict()["runs"] == 1000, f"Expected 1000 runs in {_folder_ids[0]} but got {_folder.to_dict()['runs']}"
 
     if _folder := Client().get_folder(f"/simvue_cli_tests/{_uuid}"):
         _folder.delete(recursive=True, delete_runs=True)

--- a/tests/unit/test_cli_actions.py
+++ b/tests/unit/test_cli_actions.py
@@ -220,6 +220,7 @@ def test_metadata_push_csv(create_metadata_csv: pathlib.Path) -> None:
     _folder_id = simvue_cli.actions.push_delim_metadata(
         input_file=create_metadata_csv,
         folder=_folder_name,
+        name="test_metadata_push_csv",
         global_metadata="{\"batch_number\": 0}",
         public_visible=False,
         tenant_visible=True,
@@ -237,6 +238,7 @@ def test_metadata_push_json(create_metadata_json: pathlib.Path) -> None:
     _folder_id = simvue_cli.actions.push_json_metadata(
         input_file=create_metadata_json,
         folder=_folder_name,
+        name="test_metadata_push_json",
         global_metadata="{\"batch_number\": 0}",
         public_visible=False,
         tenant_visible=True,


### PR DESCRIPTION
Fixing tests by:

* Setting num runs expected for metadata push to 40,000
* Using client.get_runs instead of folder count to find number of runs created (not sure yet if this works properly since the CLI is creating zero runs)
* Got rid of `delete_on_close` - dont think it is necessary since the fixture is yielded within the `with` block, and it was giving me errors of `E       TypeError: NamedTemporaryFile() got an unexpected keyword argument 'delete_on_close'`

Note tests now fail, but I believe this is due to bugs in the CLI, instead of due to test errors as it was before